### PR TITLE
Update wgpu to major-version release 22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ metal = { version = "0.28", optional = true }
 lazy_static = "1.4"
 core-graphics-types = "0.1"
 mach2 = "0.4"
-wgpu = { version = "^0.20", optional = true, features = ["metal", "hal"] }
+wgpu = { version = "^22.0", optional = true, features = ["metal"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.52", features = [
@@ -82,11 +82,11 @@ windows = { version = "0.52", features = [
     "ApplicationModel_Core",
     "System",
 ] }
-wgpu = { version = "0.20", optional = true, features = ["dx12", "hal"] }
-d3d12 = "0.20"
+wgpu = { version = "22.0", optional = true, features = ["dx12"] }
+d3d12 = "22.0"
 winapi = { version = "0.3", optional = true }
 
 [dev-dependencies]
 futures = "0.3"
 tokio = { version = "1.37", features = ["rt", "macros", "rt-multi-thread"] }
-wgpu = "0.20"
+wgpu = "22.0"

--- a/examples/feature_wgpu.rs
+++ b/examples/feature_wgpu.rs
@@ -42,6 +42,7 @@ fn main() {
             label: Some("wgpu adapter"),
             required_features: wgpu::Features::default(),
             required_limits: wgpu::Limits::default(),
+            memory_hints: wgpu::MemoryHints::default(),
         }, None).await.expect("Expected wgpu device");
         let gfx = Arc::new(Gfx {
             device: wgpu_device,


### PR DESCRIPTION
This PR updates version of `wgpu` crate in dependency from 0.20 to recently released version 22.0.

Because Cargo treats `wgpu` 22 and 0.2 are two distinct crates, mixing them leads to [weird link errors](https://github.com/gfx-rs/wgpu/issues/3105). This PR solves this problem.

However, this also makes CrabGrab incompatible with crates using `wgpu` 0.2.
If you think it is not acceptable, I can add a feature flag to switch the dependency to `wgpu` 0.2.