### PR TITLE
feat: add support for filtering using excluding windows

### DIFF
--- a/src/capturable_content.rs
+++ b/src/capturable_content.rs
@@ -225,6 +225,11 @@ unsafe impl Send for CapturableWindow {}
 unsafe impl Sync for CapturableWindow {}
 
 impl CapturableWindow {
+    /// Gets the id of the window
+    pub fn id(&self) -> u32 {
+        self.impl_capturable_window.id()
+    }
+
     /// Gets the title of the window
     pub fn title(&self) -> String {
         self.impl_capturable_window.title()

--- a/src/capturable_content.rs
+++ b/src/capturable_content.rs
@@ -187,6 +187,33 @@ impl ExactSizeIterator for CapturableDisplayIterator<'_> {
     }
 }
 
+/// An iterator over capturable excluding_windows
+pub struct CapturableExcludingWindowIterator<'content> {
+    content: &'content CapturableContent,
+    i: usize
+}
+
+impl Iterator for CapturableExcludingWindowIterator<'_> {
+    type Item = CapturableWindow;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < self.content.impl_capturable_content.excluding_windows.len() {
+            let i = self.i;
+            self.i += 1;
+            Some(CapturableWindow { impl_capturable_window: ImplCapturableWindow::from_impl(self.content.impl_capturable_content.excluding_windows[i].clone()) })
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.i, Some(self.content.impl_capturable_content.excluding_windows.len()))
+    }
+}
+
+impl ExactSizeIterator for CapturableExcludingWindowIterator<'_> {
+}
+
 impl CapturableContent {
     /// Requests capturable content from the OS
     /// 
@@ -201,6 +228,11 @@ impl CapturableContent {
     /// Get an iterator over the capturable windows
     pub fn windows<'a>(&'a self) -> CapturableWindowIterator<'a> {
         CapturableWindowIterator { content: self, i: 0 }
+    }
+
+    /// Get an iterator over the capturable excluding windows
+    pub fn excluding_windows<'a>(&'a self) -> CapturableExcludingWindowIterator<'a> {
+        CapturableExcludingWindowIterator { content: self, i: 0 }
     }
 
     /// Get an iterator over the capturable displays

--- a/src/capture_stream.rs
+++ b/src/capture_stream.rs
@@ -171,7 +171,7 @@ pub struct CaptureConfig {
     pub(crate) capture_audio: Option<AudioCaptureConfig>,
     pub(crate) impl_capture_config: ImplCaptureConfig,
     pub(crate) buffer_count: usize,
-    pub(crate) included_windows: Option<Vec<CapturableWindow>>
+    pub(crate) excluded_windows: Option<Vec<CapturableWindow>>
 }
 
 /// Represents an error creating the capture config
@@ -222,16 +222,16 @@ impl CaptureConfig {
             impl_capture_config: ImplCaptureConfig::new(),
             capture_audio: None,
             buffer_count: 3,
-            included_windows: None
+            excluded_windows: None
         })
     }
 
     /// Create a capture configuration for a given capturable display
-    pub fn with_display(display: CapturableDisplay, pixel_format: CapturePixelFormat, included_windows: Option<Vec<CapturableWindow>>) -> CaptureConfig {
+    pub fn with_display(display: CapturableDisplay, pixel_format: CapturePixelFormat, excluded_windows: Option<Vec<CapturableWindow>>) -> CaptureConfig {
         let rect = display.rect();
         CaptureConfig {
             target: Capturable::Display(display),
-            included_windows: included_windows,
+            excluded_windows: excluded_windows,
             pixel_format,
             output_size: rect.size,
             show_cursor: false,

--- a/src/capture_stream.rs
+++ b/src/capture_stream.rs
@@ -171,6 +171,7 @@ pub struct CaptureConfig {
     pub(crate) capture_audio: Option<AudioCaptureConfig>,
     pub(crate) impl_capture_config: ImplCaptureConfig,
     pub(crate) buffer_count: usize,
+    pub(crate) included_windows: Option<Vec<CapturableWindow>>
 }
 
 /// Represents an error creating the capture config
@@ -221,14 +222,16 @@ impl CaptureConfig {
             impl_capture_config: ImplCaptureConfig::new(),
             capture_audio: None,
             buffer_count: 3,
+            included_windows: None
         })
     }
 
     /// Create a capture configuration for a given capturable display
-    pub fn with_display(display: CapturableDisplay, pixel_format: CapturePixelFormat) -> CaptureConfig {
+    pub fn with_display(display: CapturableDisplay, pixel_format: CapturePixelFormat, included_windows: Option<Vec<CapturableWindow>>) -> CaptureConfig {
         let rect = display.rect();
         CaptureConfig {
             target: Capturable::Display(display),
+            included_windows: included_windows,
             pixel_format,
             output_size: rect.size,
             show_cursor: false,

--- a/src/platform/macos/capturable_content.rs
+++ b/src/platform/macos/capturable_content.rs
@@ -61,6 +61,10 @@ impl MacosCapturableWindow {
         }
     }
 
+    pub fn id(&self) -> u32 {
+        self.window.id().0
+    }
+
     pub fn title(&self) -> String {
         self.window.title()
     }

--- a/src/platform/macos/capturable_content.rs
+++ b/src/platform/macos/capturable_content.rs
@@ -10,6 +10,7 @@ use super::objc_wrap::{get_window_description, get_window_levels, CGMainDisplayI
 
 pub struct MacosCapturableContent {
     pub windows: Vec<SCWindow>,
+    pub excluding_windows: Vec<SCWindow>,
     pub displays: Vec<SCDisplay>,
 }
 
@@ -32,6 +33,10 @@ impl MacosCapturableContent {
                     .into_iter()
                     .filter(|window| filter.impl_capturable_content_filter.filter_scwindow(window))
                     .collect();
+                let excluding_windows = content.windows()
+                    .into_iter()
+                    .filter(|window| !filter.impl_capturable_content_filter.filter_scwindow(window))
+                    .collect();
                 let displays = content.displays()
                     .into_iter()
                     .filter(|display| filter.impl_capturable_content_filter.filter_scdisplay(display))
@@ -39,6 +44,7 @@ impl MacosCapturableContent {
                 Ok(Self {
                     windows,
                     displays,
+                    excluding_windows,
                 })
             },
             Ok(Err(error)) => {

--- a/src/platform/macos/capture_stream.rs
+++ b/src/platform/macos/capture_stream.rs
@@ -444,7 +444,7 @@ impl MacosCaptureStream {
                     }
                 }
                 let mut filter;
-                let windows = capture_config.included_windows;
+                let windows = capture_config.excluded_windows;
                 let mut sc_windows = Vec::new();
                 if let Some(windows) = windows {
                     for w in windows {

--- a/src/platform/macos/objc_wrap.rs
+++ b/src/platform/macos/objc_wrap.rs
@@ -398,7 +398,7 @@ impl NSArray {
 
     pub(crate) fn add_object<T: 'static + Encode>(&mut self, object: T) {
         unsafe {
-            let _: () = msg_send![self.0, addAnyObject: object];
+            let _: () = msg_send![self.0, addObject: object];
         }
     }
 
@@ -1215,6 +1215,22 @@ impl SCContentFilter {
         unsafe {
             let id: *mut AnyObject = msg_send![class!(SCContentFilter), alloc];
             let _: *mut AnyObject = msg_send![id, initWithDesktopIndependentWindow: window.clone()];
+            Self(id)
+        }
+    }
+
+    pub(crate) fn new_with_display_excluding_window(display: SCDisplay, windows: Option<Vec<SCWindow>>) -> Self {
+        unsafe {
+
+            let mut windows_nsarray = NSArray::new_mutable();
+            if let Some(windows) = windows {
+                for w in windows {
+                    windows_nsarray.add_object(w.0);
+                }
+            }
+
+            let id: *mut AnyObject = msg_send![class!(SCContentFilter), alloc];
+            let _: *mut AnyObject = msg_send![id, initWithDisplay: display.0 excludingWindows: windows_nsarray.0];
             Self(id)
         }
     }

--- a/src/platform/windows/capturable_content.rs
+++ b/src/platform/windows/capturable_content.rs
@@ -24,6 +24,11 @@ impl WindowsCapturableWindow {
         Self(hwnd)
     }
 
+    pub fn id(&self) -> u32 {
+        todo!("Getting ID not yet implemented for windows");
+        return 0;
+    }
+
     pub fn title(&self) -> String {
         unsafe {
             let text_length = GetWindowTextLengthW(self.0);


### PR DESCRIPTION
## What does this PR do?
This PR adds support for excluding certain windows while capturing a display.

## Why do we need this change?
We want the ability to ignore certain windows ( like the camera, cropper etc ) when capturing screen using Helmer

## How are we doing this change?
- First, we needed to move the screen capturing with display to use ScreenCaptureKit instead of CoreGraphics. Here we also add support for excluding certain windows using the `excludingWindows` param using `init`. To achieve this we also make the corresponding changes in `objc` files.
- Next we update `CapturableContent` to also return the list of windows to be excluded.
- We also update the `with_display` func to take a list of windows to be excluded. This list is then propogated forward and used while creating a stream to capture.
- Finally, we also expose a `id()` func on the `window` object to make it easier to get the ids of windows to be excluded.

## What improvements can be done?
- Add support for windows
- Improve the `excluding_windows` fetching logic to only loop through `windows` once.

## How has this been tested
- Manual testing in Helmer by connecting this version with omni, which in turn is connected to Helmer